### PR TITLE
Minimal contributor code of conduct.

### DIFF
--- a/contributor_code_of_conduct.md
+++ b/contributor_code_of_conduct.md
@@ -1,0 +1,37 @@
+# SIG-RPC Contributor Code of Conduct
+
+*This minimal code of conduct is intended for members and contributors to SIG-RPC and it's projects. Officer of SIG-RPC are bound by Society RSE's [Organisation Code of Conduct](https://society-rse.org/about/policies/code-of-conduct-for-trustees/), and formal events additionally fall under Society RSE's events Code of Conduct](https://society-rse.org/about/policies/code-of-conduct/).*
+
+## 1. Be Respectful
+
+Treat everyone with respect. No harassment, discrimination, or personal attacks.
+
+## 2. Keep Discussions Productive
+
+Focus on the technical work. Critique ideas, not people. Avoid disruptive behaviour (spam, trolling, derailing discussions).
+
+## 3. Assume Good Intent
+
+Most contributors are trying to help. Ask for clarification rather than jumping to negative conclusions.
+
+## 4. Follow SIG-RPC Officer Decisions
+
+Officers of SIG-ROC have the final say on issues, PRs, and project direction. Disagreements are fine; hostility is not.
+
+## 5. No Illegal or Unethical Content
+
+Do not contribute harmful content, stolen IP, or anything which may be considered legal within UK law.
+
+## 6. Report Problems Responsibly
+
+If you witness unacceptable behaviour, privately contact SIG-RPC's officers (sig-rpc-managers@society-rse.org).
+
+# Consequences for Violations
+
+If officers of SIG-RPC deem a contributor to have violated any of these policies one of the below actions may be taken at their discretion:
+
+- issue a private warning
+- reject contributions
+- refuse or block further contributions
+
+These actions are taken at the officers' discretion to keep the SIG-RPC community welcoming to all.

--- a/contributor_code_of_conduct.md
+++ b/contributor_code_of_conduct.md
@@ -24,7 +24,7 @@ Do not contribute harmful content, stolen IP, or anything which may be considere
 
 ## 6. Report Problems Responsibly
 
-If you witness unacceptable behaviour, privately contact SIG-RPC's officers (sig-rpc-managers@society-rse.org).
+If you witness unacceptable behaviour, privately contact SIG-RPC's officers (sig-rpc-managers@society-rse.org), more serious/urgent grievances can be raised with Society RSE Code of Conduct Committee (coc@society-rse.org) as explained in the [Complaints and Grievances Policy](https://society-rse.org/about/policies/complaints-and-grievances-policy/)
 
 # Consequences for Violations
 


### PR DESCRIPTION
Lyndsey confirmed trustee CoC applies to officers, so I've drafted (with support of AI) this broad reaching (albeit slanted towards technical contribution) code of conduct.